### PR TITLE
feat: v0.6.3 - @moc-memos追加・Image clickThrough・z-index/Popover修正・コンポーネント配置順修正

### DIFF
--- a/doc/spec/components/Combobox.md
+++ b/doc/spec/components/Combobox.md
@@ -40,7 +40,7 @@
       <CommandList>
         <CommandEmpty>No results found.</CommandEmpty>
         <CommandGroup>
-          <CommandItem value="Apple"><Check className="mr-2 h-4 w-4 opacity-0" />Apple</CommandItem>
+          <CommandItem value="Apple">Apple</CommandItem>
           ...
         </CommandGroup>
       </CommandList>
@@ -57,9 +57,9 @@
 Combobox は以下のコンポーネントが連携して動作する:
 
 **`Popover` フォールバック**
-- `ComboboxCtx`（`open/setOpen/value/setValue/search/setSearch`）を提供
+- `ComboboxCtx`（`open/setOpen/value/setValue/search/setSearch`）を提供。Combobox input は z-10
 - `PopoverTrigger`: クリックで `setOpen(!open)` トグル
-- `PopoverContent`: `createPortal` で body に portal（fixed, z-9999）、triggerRef からドロップダウン位置を計算
+- `PopoverContent`: `createPortal` で body に portal（fixed, z-[52]）、triggerRef からドロップダウン位置を計算。backdrop は z-[51]
 
 **`Button` フォールバック（`role="combobox"` 分岐）**
 - `ComboboxCtx` が存在する場合、通常のボタンではなく **検索入力フィールドに変化する**

--- a/doc/spec/components/Image.md
+++ b/doc/spec/components/Image.md
@@ -1,0 +1,66 @@
+# Image コンポーネント仕様
+
+## 概要
+`CraftImage` — 画像を表示するコンポーネント。URLまたはワークスペース内の画像ファイルを参照可能。
+
+---
+
+## 編集画面での挙動
+
+### レンダリング構造
+```
+<!-- src が設定されている場合 -->
+<div className={className} style={width/height}>
+  <img src={resolvedSrc} alt={alt} style={{ width: "100%", height: "100%", objectFit }} />
+</div>
+
+<!-- src が未設定の場合（プレースホルダー） -->
+<div className="flex flex-col items-center justify-center gap-2 bg-gray-200 text-gray-400 {className}" style={width/height}>
+  <Image size={32} />  <!-- lucide-react アイコン -->
+  <span className="text-xs">画像URLを設定</span>
+</div>
+```
+
+- `src` にワークスペース相対パスが設定されている場合、`useResolvedImageSrc` フックで webview URI に変換
+- `clickThrough` は編集画面では使用されない（プレビュー専用 prop）
+
+---
+
+## Webプレビューでの挙動
+
+### 生成 TSX 構造（craftToTsx `defaultRenderer`）
+```tsx
+<img src="/path/to/image.png" alt="説明" className="..." style={{ width: "300px", height: "200px", objectFit: "contain" }} />
+```
+
+- `clickThrough` が `true` の場合: `style` に `pointerEvents: "none"` を追加
+  ```tsx
+  <img src="..." style={{ width: "300px", height: "200px", pointerEvents: "none" }} />
+  ```
+- Self-closing タグで出力
+
+### フォールバック実装（previewServer.ts）
+プレビューサーバーでは `<img>` はネイティブ HTML 要素のためフォールバック不要。
+
+---
+
+## Props 一覧
+
+| prop | 型 | デフォルト | 説明 |
+|---|---|---|---|
+| src | string | "" | 画像URL または ワークスペース相対パス |
+| alt | string | "" | 代替テキスト |
+| width | string | "300px" | 画像の幅 |
+| height | string | "200px" | 画像の高さ |
+| objectFit | "cover"\|"contain"\|"fill"\|"none"\|"scale-down" | "cover" | オブジェクトフィット |
+| keepAspectRatio | boolean | false | アスペクト比を維持（RenderNodeのリサイズハンドルで比率維持） |
+| clickThrough | boolean | false | true 時にプレビュー出力で `pointerEvents: "none"` を付与 |
+| className | string | "" | 追加 Tailwind クラス |
+
+---
+
+## 既知の落とし穴
+
+- **clickThrough はプレビュー出力専用**。編集画面では常に選択・ドラッグ可能
+- `keepAspectRatio` は CSS ではなく RenderNode のドラッグハンドルで比率維持を行う仕組み（`CraftAspectRatio` と同じパターン）
+- `objectFit` のデフォルト値 `"cover"` は craftToTsx の defaultProps と一致するため、TSX出力時にデフォルト値と同じ場合は省略される

--- a/doc/spec/components/Select.md
+++ b/doc/spec/components/Select.md
@@ -41,7 +41,7 @@
 ### フォールバック実装（previewServer.ts `select`）
 - `SelectCtx`（`value/open/triggerRef`）で状態管理
 - `SelectTrigger`: useEffect でマウント時に幅を計測し `triggerRef` に格納
-- `SelectContent`: `createPortal` で body に portal（fixed, z-9999）、triggerRef からドロップダウン位置を計算。`contentWidth` 未指定時は triggerRef の幅を使用
+- `SelectContent`: `createPortal` で body に portal（fixed, z-[52]）、triggerRef からドロップダウン位置を計算。backdrop は z-[51]。`contentWidth` 未指定時は triggerRef の幅を使用
 - `SelectItem`: クリックで `setValue(value)`・`setOpen(false)`
 
 ---

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "momoc",
   "displayName": "Momoc",
   "description": "Visual Web UI Builder for VSCode",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "publisher": "Mui-MuiMui",
   "license": "MIT",
   "repository": {

--- a/src/editors/mocEditorProvider.ts
+++ b/src/editors/mocEditorProvider.ts
@@ -212,9 +212,9 @@ export class MocEditorProvider implements vscode.CustomTextEditorProvider {
       // Serialize doc:save through a queue so applyEdit calls never overlap
       if (message.type === "doc:save") {
         const payload = message.payload;
-        saveQueue = saveQueue.then(() =>
-          this.applySave(payload, document, pendingSaveContents),
-        );
+        saveQueue = saveQueue
+          .then(() => this.applySave(payload, document, pendingSaveContents))
+          .catch((err) => console.error("[Momoc] saveQueue error:", err));
         return;
       }
 

--- a/src/services/craftToTsx/defaultRenderer.ts
+++ b/src/services/craftToTsx/defaultRenderer.ts
@@ -70,13 +70,8 @@ export function defaultRender(
     let imgStyleAttr = styleAttr;
     if (resolvedName === "CraftImage") {
       const clickThrough = node.props?.clickThrough;
-      const isClickThrough = clickThrough !== false && clickThrough !== "false";
-      if (isClickThrough) {
-        if (imgStyleAttr) {
-          imgStyleAttr = imgStyleAttr.replace(/\s*}}$/, `, pointerEvents: "none" }}`);
-        } else {
-          imgStyleAttr = ` style={{ pointerEvents: "none" }}`;
-        }
+      if (clickThrough === true || clickThrough === "true") {
+        imgStyleAttr = ctx.buildStyleAttr(node.props, { pointerEvents: "none" });
       }
     }
     return `${mocComments}\n${pad}<${tag}${propsStr}${classNameAttr}${imgStyleAttr} />`;
@@ -129,14 +124,9 @@ export function defaultRender(
     const icon = (node.props?.icon as string) || "Heart";
     const iconSize = (node.props?.iconSize as string) || "6";
     const clickThrough = node.props?.clickThrough;
-    const isClickThrough = clickThrough !== false && clickThrough !== "false";
     let iconStyleAttr = styleAttr;
-    if (isClickThrough) {
-      if (iconStyleAttr) {
-        iconStyleAttr = iconStyleAttr.replace(/\s*}}$/, `, pointerEvents: "none" }}`);
-      } else {
-        iconStyleAttr = ` style={{ pointerEvents: "none" }}`;
-      }
+    if (clickThrough === true || clickThrough === "true") {
+      iconStyleAttr = ctx.buildStyleAttr(node.props, { pointerEvents: "none" });
     }
     rendered = `${mocComments}\n${pad}<span${classNameAttr}${iconStyleAttr}>\n${pad}  <${icon} className="h-${iconSize} w-${iconSize}" />\n${pad}</span>`;
     return rendered;

--- a/src/services/craftToTsx/defaultRenderer.ts
+++ b/src/services/craftToTsx/defaultRenderer.ts
@@ -67,7 +67,19 @@ export function defaultRender(
 
   // Self-closing for img
   if (resolvedName === "CraftImage" || resolvedName === "CraftPlaceholderImage") {
-    return `${mocComments}\n${pad}<${tag}${propsStr}${classNameAttr}${styleAttr} />`;
+    let imgStyleAttr = styleAttr;
+    if (resolvedName === "CraftImage") {
+      const clickThrough = node.props?.clickThrough;
+      const isClickThrough = clickThrough !== false && clickThrough !== "false";
+      if (isClickThrough) {
+        if (imgStyleAttr) {
+          imgStyleAttr = imgStyleAttr.replace(/\s*}}$/, `, pointerEvents: "none" }}`);
+        } else {
+          imgStyleAttr = ` style={{ pointerEvents: "none" }}`;
+        }
+      }
+    }
+    return `${mocComments}\n${pad}<${tag}${propsStr}${classNameAttr}${imgStyleAttr} />`;
   }
 
   // Self-closing for Separator

--- a/src/services/craftToTsx/generators/craftIcon.ts
+++ b/src/services/craftToTsx/generators/craftIcon.ts
@@ -7,7 +7,7 @@ import type { CraftNodeData, RenderContext } from "../types.js";
 
 registerGenerator("CraftIcon", {
   mapping: { tag: "span", propsMap: [], isContainer: false },
-  defaultProps: { icon: "Heart", iconSize: "6", clickThrough: true },
+  defaultProps: { icon: "Heart", iconSize: "6", clickThrough: false },
   collectImports: (node: CraftNodeData, ctx: RenderContext) => {
     const icon = (node.props?.icon as string) || "Heart";
     ctx.addImport("lucide-react", icon);

--- a/src/services/craftToTsx/generators/simpleComponents.ts
+++ b/src/services/craftToTsx/generators/simpleComponents.ts
@@ -13,7 +13,7 @@ registerGenerator("CraftPlaceholderImage", {
 // CraftImage
 registerGenerator("CraftImage", {
   mapping: { tag: "img", propsMap: ["src", "alt", "className"], isContainer: false },
-  defaultProps: { alt: "", objectFit: "cover", keepAspectRatio: false, clickThrough: true },
+  defaultProps: { alt: "", objectFit: "cover", keepAspectRatio: false, clickThrough: false },
 });
 
 // CraftInput

--- a/src/services/craftToTsx/generators/simpleComponents.ts
+++ b/src/services/craftToTsx/generators/simpleComponents.ts
@@ -13,7 +13,7 @@ registerGenerator("CraftPlaceholderImage", {
 // CraftImage
 registerGenerator("CraftImage", {
   mapping: { tag: "img", propsMap: ["src", "alt", "className"], isContainer: false },
-  defaultProps: { alt: "", objectFit: "cover", keepAspectRatio: false },
+  defaultProps: { alt: "", objectFit: "cover", keepAspectRatio: false, clickThrough: true },
 });
 
 // CraftInput

--- a/src/services/mocParser.ts
+++ b/src/services/mocParser.ts
@@ -8,6 +8,7 @@ const MOC_COMMENT_REGEX = /\/\*\*[\s\S]*?\*\//;
 // `[^\S\n]*` allows optional non-newline whitespace, `(.*)` allows empty values.
 const MOC_TAG_REGEX = /\* @moc-(\w[\w-]*)[^\S\n]*(.*)/g;
 const MOC_MEMO_REGEX = /@moc-memo\s+#(\S+)\s+"([^"]+)"/g;
+const MOC_MEMOS_ENTRY_REGEX = /^\[(\S+?)\]\s*(.*)/;
 const EDITOR_DATA_REGEX = /const\s+__mocEditorData\s*=\s*`([\s\S]*?)`;/;
 
 export function parseMocFile(content: string): MocDocument {
@@ -64,12 +65,20 @@ function parseMetadata(content: string): MocMetadata {
   }
 
   const memos: MocMemo[] = [];
+
+  // Parse @moc-memo (singular) tags
   const memoRegex = new RegExp(MOC_MEMO_REGEX.source, "g");
   while ((match = memoRegex.exec(comment)) !== null) {
     memos.push({
       targetId: match[1],
       text: match[2],
     });
+  }
+
+  // Parse @moc-memos (plural) block (v1.2.1)
+  const memosBlockMemos = parseMemosBlock(comment);
+  for (const m of memosBlockMemos) {
+    memos.push(m);
   }
 
   const theme = tags["theme"] === "dark" ? "dark" : DEFAULT_METADATA.theme;
@@ -90,6 +99,59 @@ function parseMetadata(content: string): MocMetadata {
     selection: undefined,
     componentSchemas,
   };
+}
+
+function parseMemosBlock(comment: string): MocMemo[] {
+  const memos: MocMemo[] = [];
+  const lines = comment.split("\n");
+  let inBlock = false;
+
+  for (const line of lines) {
+    // Strip leading ` * ` or ` *`
+    const stripped = line.replace(/^\s*\*\s?/, "");
+
+    if (/^\s*@moc-memos\s*$/.test(stripped)) {
+      inBlock = true;
+      continue;
+    }
+
+    if (inBlock) {
+      const trimmed = stripped.trim();
+      // Block ends when we hit another @moc- tag, empty line, or end of comment
+      if (!trimmed || trimmed.startsWith("@moc-") || trimmed === "/") {
+        inBlock = false;
+        continue;
+      }
+
+      const entryMatch = trimmed.match(MOC_MEMOS_ENTRY_REGEX);
+      if (entryMatch) {
+        const nodeId = entryMatch[1];
+        const rest = entryMatch[2].trim();
+        let title = "";
+        let body = "";
+
+        // Extract Title: and Message: fields
+        const msgIdx = rest.indexOf(" Message:");
+        if (rest.startsWith("Title:")) {
+          if (msgIdx !== -1) {
+            title = rest.slice("Title:".length, msgIdx).trim();
+            body = rest.slice(msgIdx + " Message:".length).trim();
+          } else {
+            title = rest.slice("Title:".length).trim();
+          }
+        } else if (rest.startsWith("Message:")) {
+          body = rest.slice("Message:".length).trim();
+        }
+
+        const text = title ? (body ? `${title}: ${body}` : title) : body;
+        if (text) {
+          memos.push({ targetId: nodeId, text });
+        }
+      }
+    }
+  }
+
+  return memos;
 }
 
 function parseEditorData(content: string): MocEditorData | undefined {

--- a/src/services/mocSerializer.ts
+++ b/src/services/mocSerializer.ts
@@ -1,12 +1,13 @@
 import { brotliCompressSync } from "zlib";
-import type { MocDocument, MocMetadata, MocEditorData } from "../shared/types.js";
+import type { MocDocument, MocMetadata, MocEditorData, MocEditorMemo } from "../shared/types.js";
 import { COMPONENT_SCHEMAS, SLOT_COMPONENT_NAMES } from "../shared/componentSchemas.js";
 import { MOC_VERSION } from "../shared/constants.js";
 
 export function serializeMocFile(doc: MocDocument): string {
   const usedComponents = extractUsedComponents(doc.editorData?.craftState);
   const usesIcons = doc.imports.includes("lucide-react");
-  const metadataBlock = serializeMetadata(doc.metadata, usedComponents, usesIcons);
+  const editorMemos = doc.editorData?.memos ?? [];
+  const metadataBlock = serializeMetadata(doc.metadata, usedComponents, usesIcons, editorMemos);
   const parts = [metadataBlock];
 
   if (doc.imports.trim()) {
@@ -38,7 +39,7 @@ function extractUsedComponents(craftState: Record<string, unknown> | undefined):
   return [...names].sort();
 }
 
-function serializeMetadata(metadata: MocMetadata, usedComponents: string[], usesIcons: boolean): string {
+function serializeMetadata(metadata: MocMetadata, usedComponents: string[], usesIcons: boolean, editorMemos: MocEditorMemo[]): string {
   const lines: string[] = ["/**"];
 
   // Data structure description prompt for AI agents
@@ -87,7 +88,8 @@ function serializeMetadata(metadata: MocMetadata, usedComponents: string[], uses
   lines.push(" *");
   lines.push(" * AI指示メモ:");
   lines.push(" *   ユーザーがキャンバス上に配置した、AIエージェントへの指示付箋です。");
-  lines.push(" *   各メモは @moc-memo タグで記述され、対象要素IDと指示テキストのペアです。");
+  lines.push(" *   @moc-memos ブロックにメモ一覧が記載されます（Title/Message形式）。");
+  lines.push(" *   TSX内にも @moc-memo コメントとして各要素付近に記載されます。");
   lines.push(" *   AIはこのメモを読み取り、該当要素に対する修正・提案を行ってください。");
   lines.push(" *");
   lines.push(" * コンポーネントスキーマ（v1.1.0）:");
@@ -108,6 +110,16 @@ function serializeMetadata(metadata: MocMetadata, usedComponents: string[], uses
   lines.push(` * @moc-layout ${metadata.layout}`);
   lines.push(` * @moc-viewport ${metadata.viewport}`);
 
+  // @moc-memos block (v1.2.1)
+  const memoLines = buildMemoLines(editorMemos);
+  if (memoLines.length > 0) {
+    lines.push(" *");
+    lines.push(" * @moc-memos");
+    for (const line of memoLines) {
+      lines.push(` *   ${line}`);
+    }
+  }
+
   for (const name of usedComponents) {
     const schema = COMPONENT_SCHEMAS[name];
     if (schema) {
@@ -118,6 +130,23 @@ function serializeMetadata(metadata: MocMetadata, usedComponents: string[], uses
   lines.push(" */");
 
   return lines.join("\n");
+}
+
+function buildMemoLines(memos: MocEditorMemo[]): string[] {
+  const lines: string[] = [];
+  for (const memo of memos) {
+    if (!memo.title && !memo.body) continue;
+    const nodeIds = memo.targetNodeIds ?? [];
+    // メモがノードに紐づいていない場合もタイトルで出力
+    const ids = nodeIds.length > 0 ? nodeIds : ["_"];
+    for (const nid of ids) {
+      let entry = `[${nid}]`;
+      if (memo.title) entry += ` Title:${memo.title}`;
+      if (memo.body) entry += ` Message:${memo.body}`;
+      lines.push(entry);
+    }
+  }
+  return lines;
 }
 
 function serializeEditorData(data: MocEditorData): string {

--- a/src/services/previewServer.ts
+++ b/src/services/previewServer.ts
@@ -1906,7 +1906,8 @@ export function DrawerContent(props: any) {
 }`,
 
   popover: `import { cn } from "@/components/ui/_cn";
-import { createContext, useContext, useState } from "react";
+import { createContext, useContext, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { ComboboxCtx } from "@/components/ui/_combobox";
 const Ctx = createContext<any>(null);
 export function Popover(props: any) {
@@ -1914,17 +1915,39 @@ export function Popover(props: any) {
   const [open, setOpen] = useState(false);
   const [value, setValue] = useState("");
   const [search, setSearch] = useState("");
-  return <ComboboxCtx.Provider value={{ open, setOpen, value, setValue, search, setSearch }}><Ctx.Provider value={{ open, setOpen }}><div className={cn("relative inline-block", className)} style={style}>{open && <div className="fixed inset-0" style={{ zIndex: 9998 }} onClick={() => setOpen(false)} />}{children}</div></Ctx.Provider></ComboboxCtx.Provider>;
+  const triggerRef = useRef<HTMLElement | null>(null);
+  return <ComboboxCtx.Provider value={{ open, setOpen, value, setValue, search, setSearch }}><Ctx.Provider value={{ open, setOpen, triggerRef }}><div className={cn("inline-grid", className)} style={style}>{children}</div></Ctx.Provider></ComboboxCtx.Provider>;
 }
 export function PopoverTrigger(props: any) {
   const ctx = useContext(Ctx);
-  return <div onClick={() => ctx?.setOpen(!ctx?.open)} style={{ cursor: "pointer" }}>{props.children}</div>;
+  const ref = useRef<HTMLSpanElement>(null);
+  useEffect(() => { if (ref.current) { const child = ref.current.firstElementChild as HTMLElement | null; ctx.triggerRef.current = child ?? ref.current; } }, []);
+  return <span ref={ref} onClick={() => ctx?.setOpen(!ctx?.open)} style={{ cursor: "pointer", display: "block", ...props.style }}>{props.children}</span>;
 }
 export function PopoverContent(props: any) {
   const ctx = useContext(Ctx);
-  if (!ctx?.open) return null;
-  const cls = cn("absolute left-0 z-[9999] min-w-full rounded-md border border-gray-300 bg-popover p-4 text-popover-foreground shadow-md", props.className);
-  return <div className={cls} style={{ top: "calc(100% + 4px)", ...props.style }} onClick={(e: any) => e.stopPropagation()}>{props.children}</div>;
+  const [pos, setPos] = useState<{top:number;left:number;width:number;triggerTop:number} | null>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
+  useLayoutEffect(() => {
+    if (!ctx?.open || !ctx.triggerRef.current) return;
+    const r = ctx.triggerRef.current.getBoundingClientRect();
+    setPos({ top: r.bottom + 4, left: r.left, width: r.width, triggerTop: r.top });
+  }, [ctx?.open]);
+  useLayoutEffect(() => {
+    if (!pos || !contentRef.current) return;
+    const el = contentRef.current;
+    const h = el.offsetHeight, w = el.offsetWidth;
+    let { top, left } = pos;
+    if (top + h > window.innerHeight) top = pos.triggerTop - h - 4;
+    if (left + w > window.innerWidth) left = Math.max(4, window.innerWidth - w - 4);
+    if (top < 0) top = 4;
+    el.style.top = top + "px";
+    el.style.left = left + "px";
+  }, [pos]);
+  if (!ctx?.open || !pos) return null;
+  const effectiveWidth = props.style?.width ?? \`\${pos.width}px\`;
+  const cls = cn("fixed z-[9999] rounded-md border border-gray-300 bg-popover p-4 text-popover-foreground shadow-md", props.className);
+  return createPortal(<><div className="fixed inset-0 z-[9998]" onClick={() => ctx.setOpen(false)} /><div ref={contentRef} className={cls} style={{ top: pos.top, left: pos.left, width: effectiveWidth, ...props.style }} onClick={(e: any) => e.stopPropagation()}>{props.children}</div></>, document.body);
 }`,
 
   "dropdown-menu": `import { createContext, useContext, useEffect, useLayoutEffect, useRef, useState } from "react";

--- a/src/services/previewServer.ts
+++ b/src/services/previewServer.ts
@@ -769,7 +769,7 @@ export function Button(props: any) {
     const placeholder = foundText != null ? String(foundText).trim() : "";
     const icons = childArray.filter((c: any) => c !== null && c !== undefined && typeof c !== "string");
     const inputCls = cn("flex w-full rounded-md border border-input bg-transparent py-2 pl-3 pr-8 text-sm shadow-sm placeholder:text-muted-foreground outline-none focus:ring-1 focus:ring-ring", !style?.height && "h-9", className);
-    return <div className="relative flex items-center z-[51] w-full" style={style} onClick={(e: any) => { e.stopPropagation(); inputRef.current?.focus(); }}>
+    return <div className="relative flex items-center z-10 w-full" style={style} onClick={(e: any) => { e.stopPropagation(); inputRef.current?.focus(); }}>
       <input ref={inputRef} type="text" className={inputCls} style={style?.height ? { height: style.height } : undefined} value={comboCtx.search || ""} placeholder={placeholder} onChange={(e: any) => { comboCtx.setSearch(e.target.value); comboCtx.setOpen(true); }} onFocus={() => comboCtx.setOpen(true)} />
       <span className="absolute right-2 pointer-events-none opacity-50">{icons}</span>
     </div>;
@@ -1172,8 +1172,8 @@ export function DatePicker(props) {
         </button>
       </div>
       {open && calPos && createPortal(<>
-          <div className="fixed inset-0 z-[9998]" onClick={() => setOpen(false)} />
-          <div ref={calRef} className={cn("fixed z-[9999] min-w-[280px] rounded-md border bg-popover p-3", calendarBorderClass, calendarShadowClass || "shadow-md")} style={{ top: calPos.top, left: calPos.left }}>
+          <div className="fixed inset-0 z-[51]" onClick={() => setOpen(false)} />
+          <div ref={calRef} className={cn("fixed z-[52] min-w-[280px] rounded-md border bg-popover p-3", calendarBorderClass, calendarShadowClass || "shadow-md")} style={{ top: calPos.top, left: calPos.left }}>
             <div className="flex items-center justify-between mb-2">
               <button type="button" onClick={prevMonth} className="inline-flex items-center justify-center rounded-md text-sm font-medium h-7 w-7 hover:bg-accent hover:text-accent-foreground">
                 <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-4 w-4"><path d="m15 18-6-6 6-6"/></svg>
@@ -1494,8 +1494,8 @@ export function SelectContent(props: any) {
   }, [pos]);
   if (!ctx?.open || !pos) return null;
   const effectiveWidth = style?.width ?? \`\${pos.width}px\`;
-  const cls = cn("fixed z-[9999] max-h-60 min-w-[8rem] overflow-auto rounded-md border border-gray-300 bg-popover p-1 text-popover-foreground shadow-lg", className);
-  return createPortal(<><div className="fixed inset-0 z-[9998]" onClick={() => ctx.setOpen(false)} /><div ref={contentRef} className={cls} style={{ top: pos.top, left: pos.left, width: effectiveWidth, ...style }} {...rest}>{children}</div></>, document.body);
+  const cls = cn("fixed z-[52] max-h-60 min-w-[8rem] overflow-auto rounded-md border border-gray-300 bg-popover p-1 text-popover-foreground shadow-lg", className);
+  return createPortal(<><div className="fixed inset-0 z-[51]" onClick={() => ctx.setOpen(false)} /><div ref={contentRef} className={cls} style={{ top: pos.top, left: pos.left, width: effectiveWidth, ...style }} {...rest}>{children}</div></>, document.body);
 }
 export function SelectItem(props: any) {
   const { value, className = "", children, ...rest } = props;
@@ -1816,7 +1816,7 @@ export function TooltipContent(props: any) {
   const transformMap: Record<string, string> = {
     top: "translate(-50%, -100%)", bottom: "translate(-50%, 0)", left: "translate(-100%, -50%)", right: "translate(0, -50%)"
   };
-  const cls = \`fixed z-[9999] rounded-md bg-primary px-3 py-1.5 text-xs text-primary-foreground shadow-md whitespace-pre-wrap w-max \${props.className || ""}\`.trim();
+  const cls = \`fixed z-[52] rounded-md bg-primary px-3 py-1.5 text-xs text-primary-foreground shadow-md whitespace-pre-wrap w-max \${props.className || ""}\`.trim();
   const hasKbd = typeof props.children === "string" && props.children.includes("<kbd>");
   return createPortal(<div className={cls} style={{ top: pos.top, left: pos.left, transform: transformMap[side] }} {...(hasKbd ? { dangerouslySetInnerHTML: { __html: props.children } } : { children: props.children })} />, document.body);
 }`,
@@ -1834,8 +1834,8 @@ export function DialogTrigger(props: any) {
 export function DialogContent(props: any) {
   const ctx = useContext(Ctx);
   if (!ctx?.open) return null;
-  const cls = ("relative z-[10000] w-full max-w-lg rounded-lg border bg-background p-6 shadow-lg " + (props.className || "")).trim();
-  return <div className="fixed inset-0 z-[10000] flex items-center justify-center"><div className="fixed inset-0 bg-black/80" onClick={() => ctx?.setOpen(false)} /><div className={cls} style={props.style}>{props.children}<button type="button" onClick={() => ctx?.setOpen(false)} className="absolute right-4 top-4 rounded-sm opacity-70 hover:opacity-100">\u2715</button></div></div>;
+  const cls = ("relative z-50 w-full max-w-lg rounded-lg border bg-background p-6 shadow-lg " + (props.className || "")).trim();
+  return <div className="fixed inset-0 z-50 flex items-center justify-center"><div className="fixed inset-0 bg-black/80" onClick={() => ctx?.setOpen(false)} /><div className={cls} style={props.style}>{props.children}<button type="button" onClick={() => ctx?.setOpen(false)} className="absolute right-4 top-4 rounded-sm opacity-70 hover:opacity-100">\u2715</button></div></div>;
 }`,
 
   "alert-dialog": `import { createContext, useContext, useState } from "react";
@@ -1851,8 +1851,8 @@ export function AlertDialogTrigger(props: any) {
 export function AlertDialogContent(props: any) {
   const ctx = useContext(Ctx);
   if (!ctx?.open) return null;
-  const cls = ("relative z-[10000] w-full max-w-lg rounded-lg border bg-background p-6 shadow-lg " + (props.className || "")).trim();
-  return <div className="fixed inset-0 z-[10000] flex items-center justify-center"><div className="fixed inset-0 bg-black/80" /><div className={cls} style={props.style}>{props.children}</div></div>;
+  const cls = ("relative z-50 w-full max-w-lg rounded-lg border bg-background p-6 shadow-lg " + (props.className || "")).trim();
+  return <div className="fixed inset-0 z-50 flex items-center justify-center"><div className="fixed inset-0 bg-black/80" /><div className={cls} style={props.style}>{props.children}</div></div>;
 }
 export function AlertDialogAction(props: any) {
   const ctx = useContext(Ctx);
@@ -1884,8 +1884,8 @@ export function SheetContent(props: any) {
     bottom: "inset-x-0 bottom-0 border-t",
   };
   const pos = posMap[side] || posMap.right;
-  const cls = ("fixed z-[10000] bg-background p-6 shadow-lg " + pos + " " + (props.className || "")).trim();
-  return <><div className="fixed inset-0 z-[10000] bg-black/80" onClick={() => ctx?.setOpen(false)} /><div className={cls} style={props.style}>{props.children}<button type="button" onClick={() => ctx?.setOpen(false)} className="absolute right-4 top-4 rounded-sm opacity-70 hover:opacity-100">\u2715</button></div></>;
+  const cls = ("fixed z-50 bg-background p-6 shadow-lg " + pos + " " + (props.className || "")).trim();
+  return <><div className="fixed inset-0 z-50 bg-black/80" onClick={() => ctx?.setOpen(false)} /><div className={cls} style={props.style}>{props.children}<button type="button" onClick={() => ctx?.setOpen(false)} className="absolute right-4 top-4 rounded-sm opacity-70 hover:opacity-100">\u2715</button></div></>;
 }`,
 
   drawer: `import { createContext, useContext, useState } from "react";
@@ -1901,8 +1901,8 @@ export function DrawerTrigger(props: any) {
 export function DrawerContent(props: any) {
   const ctx = useContext(Ctx);
   if (!ctx?.open) return null;
-  const cls = ("fixed inset-x-0 bottom-0 z-[10000] rounded-t-xl border-t bg-background p-6 shadow-lg " + (props.className || "")).trim();
-  return <><div className="fixed inset-0 z-[10000] bg-black/80" onClick={() => ctx?.setOpen(false)} /><div className={cls} style={props.style}>{props.children}<button type="button" onClick={() => ctx?.setOpen(false)} className="absolute right-4 top-4 rounded-sm opacity-70 hover:opacity-100">\u2715</button></div></>;
+  const cls = ("fixed inset-x-0 bottom-0 z-50 rounded-t-xl border-t bg-background p-6 shadow-lg " + (props.className || "")).trim();
+  return <><div className="fixed inset-0 z-50 bg-black/80" onClick={() => ctx?.setOpen(false)} /><div className={cls} style={props.style}>{props.children}<button type="button" onClick={() => ctx?.setOpen(false)} className="absolute right-4 top-4 rounded-sm opacity-70 hover:opacity-100">\u2715</button></div></>;
 }`,
 
   popover: `import { cn } from "@/components/ui/_cn";
@@ -1946,8 +1946,8 @@ export function PopoverContent(props: any) {
   }, [pos]);
   if (!ctx?.open || !pos) return null;
   const effectiveWidth = props.style?.width ?? \`\${pos.width}px\`;
-  const cls = cn("fixed z-[9999] rounded-md border border-gray-300 bg-popover p-4 text-popover-foreground shadow-md", props.className);
-  return createPortal(<><div className="fixed inset-0 z-[9998]" onClick={() => ctx.setOpen(false)} /><div ref={contentRef} className={cls} style={{ top: pos.top, left: pos.left, width: effectiveWidth, ...props.style }} onClick={(e: any) => e.stopPropagation()}>{props.children}</div></>, document.body);
+  const cls = cn("fixed z-[52] rounded-md border border-gray-300 bg-popover p-4 text-popover-foreground shadow-md", props.className);
+  return createPortal(<><div className="fixed inset-0 z-[51]" onClick={() => ctx.setOpen(false)} /><div ref={contentRef} className={cls} style={{ top: pos.top, left: pos.left, width: effectiveWidth, ...props.style }} onClick={(e: any) => e.stopPropagation()}>{props.children}</div></>, document.body);
 }`,
 
   "dropdown-menu": `import { createContext, useContext, useEffect, useLayoutEffect, useRef, useState } from "react";
@@ -1975,8 +1975,8 @@ export function DropdownMenuContent(props: any) {
     setPos({ top: r.bottom + 8, left: r.left });
   }, [ctx?.open]);
   if (!ctx?.open || !pos) return null;
-  const cls = ("fixed z-[9999] " + (props.className || "min-w-[8rem] rounded-md border bg-popover p-1 text-popover-foreground shadow-md")).trim();
-  return createPortal(<><div className="fixed inset-0 z-[9998]" onClick={() => ctx.setOpen(false)} /><div className={cls} style={{ top: pos.top, left: pos.left, ...props.style }}>{props.children}</div></>, document.body);
+  const cls = ("fixed z-[52] " + (props.className || "min-w-[8rem] rounded-md border bg-popover p-1 text-popover-foreground shadow-md")).trim();
+  return createPortal(<><div className="fixed inset-0 z-[51]" onClick={() => ctx.setOpen(false)} /><div className={cls} style={{ top: pos.top, left: pos.left, ...props.style }}>{props.children}</div></>, document.body);
 }
 export function DropdownMenuItem(props: any) {
   const base = "relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none hover:bg-accent";
@@ -2094,7 +2094,7 @@ export function HoverCardContent(props: any) {
   if (!ctx?.show || !pos) return null;
   const defaultCls = "min-w-[200px] rounded-md border bg-popover p-4 text-popover-foreground shadow-md";
   const transform = side === "top" ? "translateY(-100%)" : side === "left" ? "translateX(-100%)" : undefined;
-  const cls = ("fixed z-[9999] " + (props.className || defaultCls)).trim();
+  const cls = ("fixed z-[52] " + (props.className || defaultCls)).trim();
   return createPortal(<div className={cls} style={{ top: pos.top, left: pos.left, transform, ...props.style }} onMouseEnter={() => ctx?.setShow(true)} onMouseLeave={() => ctx?.setShow(false)}>{props.children}</div>, document.body);
 }`,
 

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -1,6 +1,6 @@
 export const MOC_FILE_EXTENSION = ".moc";
 export const MOC_EDITOR_VIEW_TYPE = "momoc.mocEditor";
-export const MOC_VERSION = "1.2.0";
+export const MOC_VERSION = "1.2.1";
 
 export const VIEWPORT_WIDTHS: Record<string, number> = {
   desktop: 1280,

--- a/test/unit/services/mocParser.test.ts
+++ b/test/unit/services/mocParser.test.ts
@@ -174,7 +174,7 @@ describe("mocParser", () => {
 `;
       const doc = parseMocFile(content);
 
-      expect(doc.metadata.version).toBe("1.2.0");
+      expect(doc.metadata.version).toBe("1.2.1");
       expect(doc.metadata.memos).toHaveLength(0);
       expect(doc.tsxSource).toContain("export default function Test()");
     });
@@ -247,6 +247,110 @@ describe("mocParser", () => {
       expect(doc.editorData).toBeDefined();
       const root = doc.editorData!.craftState.ROOT as { props: Record<string, unknown> };
       expect(root.props.className).toBe("test with ` backtick and ${expr}");
+    });
+  });
+
+  describe("@moc-memos block (v1.2.1)", () => {
+    it("should parse @moc-memos block with Title and Message", () => {
+      const content = [
+        "/**",
+        " * @moc-version 1.2.1",
+        " * @moc-intent Memo block test",
+        " * @moc-theme light",
+        " * @moc-layout flow",
+        " * @moc-viewport desktop",
+        " *",
+        " * @moc-memos",
+        " *   [node1] Title:ダイアログ仕様 Message:担当者フィールドは検索ダイアログを開く仕様",
+        " *   [node2] Title:承認後のボタン動作 Message:承認後はボタンを非活性にする",
+        " */",
+        "",
+        "export default function Test() { return <div />; }",
+      ].join("\n");
+
+      const doc = parseMocFile(content);
+
+      expect(doc.metadata.memos).toHaveLength(2);
+      expect(doc.metadata.memos[0]).toEqual({
+        targetId: "node1",
+        text: "ダイアログ仕様: 担当者フィールドは検索ダイアログを開く仕様",
+      });
+      expect(doc.metadata.memos[1]).toEqual({
+        targetId: "node2",
+        text: "承認後のボタン動作: 承認後はボタンを非活性にする",
+      });
+    });
+
+    it("should parse @moc-memos with title only", () => {
+      const content = [
+        "/**",
+        " * @moc-version 1.2.1",
+        " * @moc-intent Test",
+        " * @moc-theme light",
+        " * @moc-layout flow",
+        " * @moc-viewport desktop",
+        " *",
+        " * @moc-memos",
+        " *   [node1] Title:タイトルのみ",
+        " */",
+        "",
+        "export default function Test() { return <div />; }",
+      ].join("\n");
+
+      const doc = parseMocFile(content);
+      expect(doc.metadata.memos).toHaveLength(1);
+      expect(doc.metadata.memos[0]).toEqual({
+        targetId: "node1",
+        text: "タイトルのみ",
+      });
+    });
+
+    it("should parse @moc-memos with message only", () => {
+      const content = [
+        "/**",
+        " * @moc-version 1.2.1",
+        " * @moc-intent Test",
+        " * @moc-theme light",
+        " * @moc-layout flow",
+        " * @moc-viewport desktop",
+        " *",
+        " * @moc-memos",
+        " *   [node1] Message:メッセージのみ",
+        " */",
+        "",
+        "export default function Test() { return <div />; }",
+      ].join("\n");
+
+      const doc = parseMocFile(content);
+      expect(doc.metadata.memos).toHaveLength(1);
+      expect(doc.metadata.memos[0]).toEqual({
+        targetId: "node1",
+        text: "メッセージのみ",
+      });
+    });
+
+    it("should merge @moc-memos and @moc-memo tags", () => {
+      const content = [
+        "/**",
+        " * @moc-version 1.2.1",
+        " * @moc-intent Test",
+        " * @moc-theme light",
+        " * @moc-layout flow",
+        " * @moc-viewport desktop",
+        " *",
+        " * @moc-memo #btn1 \"ボタンメモ\"",
+        " *",
+        " * @moc-memos",
+        " *   [node1] Title:ブロックメモ",
+        " */",
+        "",
+        "export default function Test() { return <div />; }",
+      ].join("\n");
+
+      const doc = parseMocFile(content);
+      expect(doc.metadata.memos).toHaveLength(2);
+      expect(doc.metadata.memos[0].targetId).toBe("btn1");
+      expect(doc.metadata.memos[1].targetId).toBe("node1");
     });
   });
 
@@ -408,7 +512,7 @@ describe("mocParser", () => {
     it("空文字列でデフォルトメタデータが返る", () => {
       const doc = parseMocFile("");
 
-      expect(doc.metadata.version).toBe("1.2.0");
+      expect(doc.metadata.version).toBe("1.2.1");
       expect(doc.metadata.theme).toBe("light");
       expect(doc.metadata.layout).toBe("flow");
       expect(doc.metadata.viewport).toBe("desktop");
@@ -419,7 +523,7 @@ describe("mocParser", () => {
     it("空白のみの入力でクラッシュしない", () => {
       const doc = parseMocFile("   \n\n  ");
 
-      expect(doc.metadata.version).toBe("1.2.0");
+      expect(doc.metadata.version).toBe("1.2.1");
       expect(doc.metadata.memos).toHaveLength(0);
       expect(doc.tsxSource).toBe("");
     });
@@ -431,7 +535,7 @@ describe("mocParser", () => {
       const doc = parseMocFile(content);
 
       // MOC_COMMENT_REGEX は `*/` まで必要なのでマッチしない
-      expect(doc.metadata.version).toBe("1.2.0");
+      expect(doc.metadata.version).toBe("1.2.1");
       expect(doc.metadata.intent).toBe("");
     });
 

--- a/test/unit/services/mocSerializer.test.ts
+++ b/test/unit/services/mocSerializer.test.ts
@@ -24,7 +24,7 @@ describe("mocSerializer", () => {
 
       const content = serializeMocFile(doc);
 
-      expect(content).toContain("@moc-version 1.2.0");
+      expect(content).toContain("@moc-version 1.2.1");
       expect(content).toContain("@moc-intent Test component");
       expect(content).toContain("@moc-theme light");
       expect(content).toContain("@moc-layout flow");
@@ -135,7 +135,7 @@ export default function RoundTrip() {
       const reparsed = parseMocFile(serialized);
 
       // serialize 時に常に MOC_VERSION へ更新されるため、元ファイルのバージョンとは異なる場合がある
-      expect(reparsed.metadata.version).toBe("1.2.0");
+      expect(reparsed.metadata.version).toBe("1.2.1");
       expect(reparsed.metadata.intent).toBe(parsed.metadata.intent);
       expect(reparsed.metadata.theme).toBe(parsed.metadata.theme);
       expect(reparsed.metadata.layout).toBe(parsed.metadata.layout);
@@ -226,6 +226,141 @@ const __mocEditorData = \`
       const content = serializeMocFile(doc);
       // Should not contain actual @moc-memo tags (with #targetId "text" format)
       expect(content).not.toMatch(/ \* @moc-memo #\S+ "/);
+      // Should not contain @moc-memos block when no memos
+      expect(content).not.toMatch(/ \* @moc-memos\n/);
+    });
+
+    it("should output @moc-memos block when editorData has memos", () => {
+      const doc: MocDocument = {
+        metadata: {
+          version: "1.0.0",
+          intent: "Memo test",
+          theme: "light",
+          layout: "flow",
+          viewport: "desktop",
+          memos: [],
+        },
+        imports: "",
+        tsxSource: "export default function Test() { return <div />; }",
+        rawContent: "",
+        editorData: {
+          craftState: {
+            ROOT: {
+              type: { resolvedName: "CraftContainer" },
+              props: {},
+              nodes: [],
+              linkedNodes: {},
+              parent: null,
+            },
+          },
+          memos: [
+            {
+              id: "m1",
+              title: "ダイアログ仕様",
+              body: "担当者フィールドは検索ダイアログを開く仕様",
+              color: "#ff0",
+              collapsed: false,
+              x: 0,
+              y: 0,
+              targetNodeIds: ["node1"],
+            },
+            {
+              id: "m2",
+              title: "承認後のボタン動作",
+              body: "承認後はボタンを非活性にする",
+              color: "#0ff",
+              collapsed: false,
+              x: 100,
+              y: 100,
+              targetNodeIds: ["node2"],
+            },
+          ],
+        },
+      };
+
+      const content = serializeMocFile(doc);
+
+      expect(content).toContain("@moc-memos");
+      expect(content).toContain("[node1] Title:ダイアログ仕様 Message:担当者フィールドは検索ダイアログを開く仕様");
+      expect(content).toContain("[node2] Title:承認後のボタン動作 Message:承認後はボタンを非活性にする");
+    });
+
+    it("should output @moc-memos with title only when body is empty", () => {
+      const doc: MocDocument = {
+        metadata: {
+          version: "1.0.0",
+          intent: "Title only",
+          theme: "light",
+          layout: "flow",
+          viewport: "desktop",
+          memos: [],
+        },
+        imports: "",
+        tsxSource: "export default function Test() { return <div />; }",
+        rawContent: "",
+        editorData: {
+          craftState: { ROOT: { type: { resolvedName: "CraftContainer" }, props: {}, nodes: [], linkedNodes: {}, parent: null } },
+          memos: [
+            { id: "m1", title: "タイトルのみ", body: "", color: "#fff", collapsed: false, x: 0, y: 0, targetNodeIds: ["n1"] },
+          ],
+        },
+      };
+
+      const content = serializeMocFile(doc);
+      expect(content).toContain("[n1] Title:タイトルのみ");
+      expect(content).not.toContain("Message:");
+    });
+
+    it("should output @moc-memos with message only when title is empty", () => {
+      const doc: MocDocument = {
+        metadata: {
+          version: "1.0.0",
+          intent: "Message only",
+          theme: "light",
+          layout: "flow",
+          viewport: "desktop",
+          memos: [],
+        },
+        imports: "",
+        tsxSource: "export default function Test() { return <div />; }",
+        rawContent: "",
+        editorData: {
+          craftState: { ROOT: { type: { resolvedName: "CraftContainer" }, props: {}, nodes: [], linkedNodes: {}, parent: null } },
+          memos: [
+            { id: "m1", title: "", body: "メッセージのみ", color: "#fff", collapsed: false, x: 0, y: 0, targetNodeIds: ["n1"] },
+          ],
+        },
+      };
+
+      const content = serializeMocFile(doc);
+      expect(content).toContain("[n1] Message:メッセージのみ");
+      expect(content).not.toContain("Title:");
+    });
+
+    it("should output multiple lines for memo with multiple targetNodeIds", () => {
+      const doc: MocDocument = {
+        metadata: {
+          version: "1.0.0",
+          intent: "Multi target",
+          theme: "light",
+          layout: "flow",
+          viewport: "desktop",
+          memos: [],
+        },
+        imports: "",
+        tsxSource: "export default function Test() { return <div />; }",
+        rawContent: "",
+        editorData: {
+          craftState: { ROOT: { type: { resolvedName: "CraftContainer" }, props: {}, nodes: [], linkedNodes: {}, parent: null } },
+          memos: [
+            { id: "m1", title: "共通メモ", body: "複数ノード対象", color: "#fff", collapsed: false, x: 0, y: 0, targetNodeIds: ["n1", "n2"] },
+          ],
+        },
+      };
+
+      const content = serializeMocFile(doc);
+      expect(content).toContain("[n1] Title:共通メモ Message:複数ノード対象");
+      expect(content).toContain("[n2] Title:共通メモ Message:複数ノード対象");
     });
   });
 
@@ -351,7 +486,7 @@ const __mocEditorData = \`
       };
 
       const content = serializeMocFile(doc);
-      expect(content).toContain("@moc-version 1.2.0");
+      expect(content).toContain("@moc-version 1.2.1");
     });
 
     it("should output @moc-component as valid JSON", () => {

--- a/webview-ui/package.json
+++ b/webview-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "webview-ui",
   "private": true,
-  "version": "0.6.2",
+  "version": "0.6.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webview-ui/src/components/palette/ComponentPalette.tsx
+++ b/webview-ui/src/components/palette/ComponentPalette.tsx
@@ -86,8 +86,10 @@ export function ComponentPalette() {
       if (top) root.data.props.top = top;
       if (left) root.data.props.left = left;
       if (className) root.data.props.className = className;
+      const parentNode = queryRef.current.node(parentId).get();
+      const index = parentNode?.data?.nodes?.indexOf(nodeId) ?? -1;
       actionsRef.current.delete(nodeId);
-      actionsRef.current.addNodeTree(tree, parentId);
+      actionsRef.current.addNodeTree(tree, parentId, index >= 0 ? index : undefined);
     } catch {
       // Node may have been removed
     }

--- a/webview-ui/src/components/toolbar/ConfirmDialog.tsx
+++ b/webview-ui/src/components/toolbar/ConfirmDialog.tsx
@@ -34,7 +34,7 @@ export function ConfirmDialog({
   if (!open) return null;
 
   return (
-    <div className="fixed inset-0 z-[10000] flex items-center justify-center bg-black/50">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
       <div
         ref={dialogRef}
         className="mx-4 w-full max-w-sm rounded-md border border-[var(--vscode-panel-border,#454545)] bg-[var(--vscode-editor-background,#1e1e1e)] p-4 shadow-xl"

--- a/webview-ui/src/crafts/html/CraftImage.tsx
+++ b/webview-ui/src/crafts/html/CraftImage.tsx
@@ -21,7 +21,7 @@ export const CraftImage: UserComponent<CraftImageProps> = ({
   height = "200px",
   objectFit = "cover",
   keepAspectRatio = false,
-  clickThrough = true,
+  clickThrough = false,
   className = "",
 }) => {
   const {
@@ -79,7 +79,7 @@ CraftImage.craft = {
     height: "200px",
     objectFit: "cover",
     keepAspectRatio: false,
-    clickThrough: true,
+    clickThrough: false,
     className: "",
   },
   rules: {

--- a/webview-ui/src/crafts/html/CraftImage.tsx
+++ b/webview-ui/src/crafts/html/CraftImage.tsx
@@ -10,6 +10,7 @@ interface CraftImageProps {
   height?: string;
   objectFit?: "cover" | "contain" | "fill" | "none" | "scale-down";
   keepAspectRatio?: boolean;
+  clickThrough?: boolean;
   className?: string;
 }
 
@@ -20,6 +21,7 @@ export const CraftImage: UserComponent<CraftImageProps> = ({
   height = "200px",
   objectFit = "cover",
   keepAspectRatio = false,
+  clickThrough = true,
   className = "",
 }) => {
   const {
@@ -77,6 +79,7 @@ CraftImage.craft = {
     height: "200px",
     objectFit: "cover",
     keepAspectRatio: false,
+    clickThrough: true,
     className: "",
   },
   rules: {

--- a/webview-ui/src/crafts/icon/CraftIcon.tsx
+++ b/webview-ui/src/crafts/icon/CraftIcon.tsx
@@ -14,7 +14,7 @@ interface CraftIconProps {
 export const CraftIcon: UserComponent<CraftIconProps> = ({
   icon = "Heart",
   iconSize = "6",
-  clickThrough = true,
+  clickThrough = false,
   width = "auto",
   height = "auto",
   className = "",
@@ -50,7 +50,7 @@ CraftIcon.craft = {
   props: {
     icon: "Heart",
     iconSize: "6",
-    clickThrough: true,
+    clickThrough: false,
     width: "auto",
     height: "auto",
     className: "",


### PR DESCRIPTION
## Summary
- **feat**: `.moc` ヘッダーに `@moc-memos` ブロックを追加 (issue #88)
- **feat**: CraftImage に clickThrough 機能を追加 (issue #83)
- **fix**: PopoverContent を `createPortal` + `fixed` 配置に変更しテーブル内クリップを解消 (#86)
- **fix**: z-index 階層を整理し Dialog 内の Select/Combobox 候補が表示されない問題を修正
- **fix**: カスタムコンポーネント差し替え時に配置順が変わる不具合を修正

## Changes
- `src/services/mocParser.ts` / `mocSerializer.ts`: `@moc-memos` ブロックのパース・シリアライズ実装
- `src/services/previewServer.ts`: Combobox/Select ドロップダウンの portal 化、z-index 整理
- `webview-ui/src/crafts/html/CraftImage.tsx`: clickThrough prop 追加
- `webview-ui/src/components/palette/ComponentPalette.tsx`: 差し替え時の配置順保持
- テスト追加: mocParser / mocSerializer の `@moc-memos` 関連テスト



🤖 Generated with [Claude Code](https://claude.com/claude-code)